### PR TITLE
feat: modernize LuCI compatibility and complete zh_Hans i18n

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,16 @@
 include $(TOPDIR)/rules.mk
 
+LUCI_TITLE:=LuCI MiniGate (DDNS + ACME + Reverse Proxy + Login Guard)
+LUCI_DEPENDS:=+luci-base +luci-compat +nginx-ssl +openssl-util +wget +curl +jsonfilter +coreutils-stat +nftables
+LUCI_PKGARCH:=all
+
 PKG_NAME:=luci-app-minigate
 PKG_VERSION:=1.3.5
 PKG_RELEASE:=1
 PKG_LICENSE:=MIT
 PKG_MAINTAINER:=MiniGate
 
-include $(INCLUDE_DIR)/package.mk
-
-define Package/$(PKG_NAME)
-	SECTION:=luci
-	CATEGORY:=LuCI
-	SUBMENU:=3. Applications
-	TITLE:=LuCI - MiniGate (DDNS + ACME + Reverse Proxy + Login Guard)
-	DEPENDS:=+luci-base +nginx-ssl +openssl-util +wget +curl +jsonfilter +coreutils-stat +nftables
-	PKGARCH:=all
-endef
+include $(TOPDIR)/feeds/luci/luci.mk
 
 define Package/$(PKG_NAME)/description
 Lightweight gateway management for OpenWrt: Cloudflare DDNS, Let's Encrypt SSL certificates,
@@ -26,11 +21,7 @@ define Package/$(PKG_NAME)/conffiles
 /etc/config/minigate
 endef
 
-define Build/Compile
-endef
-
 define Package/$(PKG_NAME)/install
-	# LuCI files
 	$(INSTALL_DIR) $(1)/usr/lib/lua/luci/controller
 	$(INSTALL_DIR) $(1)/usr/lib/lua/luci/model/cbi/minigate
 	$(INSTALL_DIR) $(1)/usr/lib/lua/luci/view/minigate
@@ -38,41 +29,37 @@ define Package/$(PKG_NAME)/install
 	$(CP) ./luasrc/model/cbi/minigate/*.lua $(1)/usr/lib/lua/luci/model/cbi/minigate/
 	$(CP) ./luasrc/view/minigate/*.htm $(1)/usr/lib/lua/luci/view/minigate/
 
-	# Backend scripts
+	$(INSTALL_DIR) $(1)/usr/share/rpcd/acl.d
+	$(INSTALL_DATA) ./root/usr/share/rpcd/acl.d/luci-app-minigate.json $(1)/usr/share/rpcd/acl.d/
+
+	$(INSTALL_DIR) $(1)/usr/share/luci/menu.d
+	$(INSTALL_DATA) ./root/usr/share/luci/menu.d/luci-app-minigate.json $(1)/usr/share/luci/menu.d/
+
 	$(INSTALL_DIR) $(1)/usr/lib/minigate
 	$(INSTALL_BIN) ./root/usr/lib/minigate/ddns.sh $(1)/usr/lib/minigate/
 	$(INSTALL_BIN) ./root/usr/lib/minigate/acme.sh $(1)/usr/lib/minigate/
 	$(INSTALL_BIN) ./root/usr/lib/minigate/proxy.sh $(1)/usr/lib/minigate/
 	$(INSTALL_BIN) ./root/usr/lib/minigate/login_guard.sh $(1)/usr/lib/minigate/
+	$(INSTALL_BIN) ./root/usr/lib/minigate/geofence.sh $(1)/usr/lib/minigate/
 
-	# Config
 	$(INSTALL_DIR) $(1)/etc/config
-	$(CP) ./root/etc/config/minigate $(1)/etc/config/
+	$(INSTALL_CONF) ./root/etc/config/minigate $(1)/etc/config/
 
-	# Init script
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./root/etc/init.d/minigate $(1)/etc/init.d/
 
-	# Data directories
 	$(INSTALL_DIR) $(1)/etc/minigate/acme
 	$(INSTALL_DIR) $(1)/etc/minigate/certs
-	$(INSTALL_DIR) $(1)/etc/minigate/nginx
 	$(INSTALL_DIR) $(1)/etc/minigate/nginx/sites
 	$(INSTALL_DIR) $(1)/etc/minigate/login-guard
-
-	# i18n / translations
-	$(INSTALL_DIR) $(1)/usr/lib/lua/luci/i18n
-	[ ! -f ./po/zh-cn/minigate.po ] || $(STAGING_DIR_HOSTPKG)/bin/po2lmo ./po/zh-cn/minigate.po $(1)/usr/lib/lua/luci/i18n/minigate.zh-cn.lmo
 endef
 
 define Package/$(PKG_NAME)/postinst
 #!/bin/sh
 [ -n "$${IPKG_INSTROOT}" ] || {
-	chmod +x /etc/init.d/minigate
-	chmod +x /usr/lib/minigate/*.sh
 	/etc/init.d/minigate enable
-	echo "MiniGate installed. Configure at: LuCI → Services → MiniGate"
 }
+exit 0
 endef
 
 define Package/$(PKG_NAME)/prerm
@@ -81,6 +68,7 @@ define Package/$(PKG_NAME)/prerm
 	/etc/init.d/minigate stop
 	/etc/init.d/minigate disable
 }
+exit 0
 endef
 
 $(eval $(call BuildPackage,$(PKG_NAME)))

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 include $(TOPDIR)/rules.mk
 
 LUCI_TITLE:=LuCI MiniGate (DDNS + ACME + Reverse Proxy + Login Guard)
-LUCI_DEPENDS:=+luci-base +luci-compat +nginx-ssl +openssl-util +wget +curl +jsonfilter +coreutils-stat +nftables
+LUCI_DEPENDS:=+luci-base +luci-compat +luci-mod-admin-full +nginx-ssl +openssl-util +wget +curl +jsonfilter +coreutils-stat +nftables
 LUCI_PKGARCH:=all
 
 PKG_NAME:=luci-app-minigate
@@ -31,9 +31,6 @@ define Package/$(PKG_NAME)/install
 
 	$(INSTALL_DIR) $(1)/usr/share/rpcd/acl.d
 	$(INSTALL_DATA) ./root/usr/share/rpcd/acl.d/luci-app-minigate.json $(1)/usr/share/rpcd/acl.d/
-
-	$(INSTALL_DIR) $(1)/usr/share/luci/menu.d
-	$(INSTALL_DATA) ./root/usr/share/luci/menu.d/luci-app-minigate.json $(1)/usr/share/luci/menu.d/
 
 	$(INSTALL_DIR) $(1)/usr/lib/minigate
 	$(INSTALL_BIN) ./root/usr/lib/minigate/ddns.sh $(1)/usr/lib/minigate/

--- a/luasrc/controller/minigate.lua
+++ b/luasrc/controller/minigate.lua
@@ -2,12 +2,12 @@ module("luci.controller.minigate", package.seeall)
 
 function index()
     entry({"admin","services","minigate"}, alias("admin","services","minigate","general"), "MiniGate", 60).dependent=false
-    entry({"admin","services","minigate","general"}, cbi("minigate/general"), "总览", 10)
-    entry({"admin","services","minigate","ddns"}, cbi("minigate/ddns"), "动态DNS", 20)
-    entry({"admin","services","minigate","acme"}, cbi("minigate/acme"), "SSL 证书", 30)
-    entry({"admin","services","minigate","proxy"}, cbi("minigate/proxy"), "反向代理", 40)
-    entry({"admin","services","minigate","login_guard"}, cbi("minigate/login_guard"), "登录防护", 45)
-    entry({"admin","services","minigate","log"}, template("minigate/log"), "日志", 50)
+    entry({"admin","services","minigate","general"}, cbi("minigate/general"), translate("Overview"), 10)
+    entry({"admin","services","minigate","ddns"}, cbi("minigate/ddns"), translate("Dynamic DNS"), 20)
+    entry({"admin","services","minigate","acme"}, cbi("minigate/acme"), translate("SSL Certificate"), 30)
+    entry({"admin","services","minigate","proxy"}, cbi("minigate/proxy"), translate("Reverse Proxy"), 40)
+    entry({"admin","services","minigate","login_guard"}, cbi("minigate/login_guard"), translate("Login Guard"), 45)
+    entry({"admin","services","minigate","log"}, template("minigate/log"), translate("Log"), 50)
     entry({"admin","services","minigate","status"}, call("action_status")).leaf=true
     entry({"admin","services","minigate","get_log"}, call("action_get_log")).leaf=true
     entry({"admin","services","minigate","acme_install"}, call("action_acme_install")).leaf=true
@@ -115,7 +115,7 @@ end
 function action_acme_install()
     local sys=require"luci.sys"; sys.call("/bin/sh /usr/lib/minigate/acme.sh install 2>&1")
     local fs=require"nixio.fs"; local ok=fs.access("/etc/minigate/acme/data/acme.sh")and fs.access("/etc/minigate/acme/data/dnsapi/dns_cf.sh")
-    luci.http.prepare_content("application/json"); luci.http.write_json({success=ok,message=ok and"安装成功"or"安装失败"})
+    luci.http.prepare_content("application/json"); luci.http.write_json({success=ok,message=ok and translate("Installation successful") or translate("Installation failed")})
 end
 
 function action_acme_issue()
@@ -123,7 +123,7 @@ function action_acme_issue()
     local cmd="/bin/sh /usr/lib/minigate/acme.sh issue"; if d~=""then cmd=cmd.." '"..d.."'"end
     sys.call(cmd.." 2>&1")
     local uci=require"luci.model.uci".cursor(); local st=uci:get("minigate","acme","status")or"unknown"
-    luci.http.prepare_content("application/json"); luci.http.write_json({success=(st=="ok"),message=(st=="ok")and"签发成功！"or"签发失败，查看日志"})
+    luci.http.prepare_content("application/json"); luci.http.write_json({success=(st=="ok"),message=(st=="ok") and translate("Certificate issued successfully") or translate("Certificate issuance failed, check log")})
 end
 
 function action_ddns_sync()
@@ -204,7 +204,7 @@ function action_geo_lookup()
     -- 安全校验：只允许 IP 地址字符
     if not ip:match("^[%d%.%:a-fA-F]+$") then
         luci.http.prepare_content("application/json")
-        luci.http.write_json({ ip = ip, geo = "无效IP" })
+        luci.http.write_json({ ip = ip, geo = translate("Invalid IP") })
         return
     end
 
@@ -262,9 +262,9 @@ function action_geo_lookup()
         end
     end
 
-    fs.writefile(cache_file, geo or "未知")
+    fs.writefile(cache_file, geo or translate("Unknown"))
     luci.http.prepare_content("application/json")
-    luci.http.write_json({ ip = ip, geo = geo or "未知" })
+    luci.http.write_json({ ip = ip, geo = geo or translate("Unknown") })
 end
 
 -- ============== 登录防护 API ==============
@@ -378,7 +378,7 @@ function action_lg_ban()
     local ip = luci.http.formvalue("ip") or ""
     if not ip:match("^%d+%.%d+%.%d+%.%d+$") then
         luci.http.prepare_content("application/json")
-        luci.http.write_json({success=false, error="无效 IP"})
+        luci.http.write_json({success=false, error=translate("Invalid IP")})
         return
     end
     local rc = sys.call("/bin/sh /usr/lib/minigate/login_guard.sh ban '" .. ip .. "' >/dev/null 2>&1")
@@ -391,7 +391,7 @@ function action_lg_unban()
     local ip = luci.http.formvalue("ip") or ""
     if not ip:match("^%d+%.%d+%.%d+%.%d+$") then
         luci.http.prepare_content("application/json")
-        luci.http.write_json({success=false, error="无效 IP"})
+        luci.http.write_json({success=false, error=translate("Invalid IP")})
         return
     end
     local rc = sys.call("/bin/sh /usr/lib/minigate/login_guard.sh unban '" .. ip .. "' >/dev/null 2>&1")

--- a/luasrc/model/cbi/minigate/acme.lua
+++ b/luasrc/model/cbi/minigate/acme.lua
@@ -6,27 +6,30 @@ local uc=require"luci.model.uci".cursor()
 local dd={}
 uc:foreach("minigate","ddns",function(sec) if sec.domain and sec.domain~=""then dd[#dd+1]=sec.domain end end)
 
-m=Map("minigate","MiniGate - SSL 证书","ACME（Let's Encrypt）自动签发。域名和令牌自动关联「动态DNS」。")
+m=Map("minigate", translate("MiniGate - SSL Certificate"), translate("Automatic ACME (Let's Encrypt) certificate issuance. Domain and token are auto-linked from Dynamic DNS."))
 
-s=m:section(NamedSection,"acme","acme","ACME 设置"); s.anonymous=true
+s=m:section(NamedSection,"acme","acme", translate("ACME Settings")); s.anonymous=true
 
-o=s:option(Flag,"enabled","启用 ACME"); o.rmempty=false
+o=s:option(Flag,"enabled", translate("Enable ACME")); o.rmempty=false
 
-o=s:option(Value,"email","账户邮箱"); o.placeholder="admin@example.com"; o.rmempty=true
-o.description="可选。"
+o=s:option(Value,"email", translate("Account email")); o.placeholder="admin@example.com"; o.rmempty=true
+o.description= translate("Optional.")
 
-o=s:option(ListValue,"key_type","密钥类型")
-o:value("ec-256","ECC P-256（推荐）"); o:value("ec-384","ECC P-384"); o:value("rsa-2048","RSA 2048"); o:value("rsa-4096","RSA 4096")
+o=s:option(ListValue,"key_type", translate("Key type"))
+o:value("ec-256","ECC P-256 (" .. translate("recommended") .. ")"); o:value("ec-384","ECC P-384"); o:value("rsa-2048","RSA 2048"); o:value("rsa-4096","RSA 4096")
 o.default="ec-256"
 
-o=s:option(Flag,"staging","测试模式"); o.rmempty=false; o.default="1"
-o.description="正式使用请关闭。"
+o=s:option(Flag,"staging", translate("Staging mode")); o.rmempty=false; o.default="1"
+o.description= translate("Disable for production use.")
 
--- 证书列表
-o=s:option(DummyValue,"_certs","已签发证书"); o.rawhtml=true
+o=s:option(DummyValue,"_certs", translate("Issued certificates")); o.rawhtml=true
 o.cfgvalue=function()
+    local t_domain  = translate("Domain")
+    local t_expires = translate("Expires")
+    local t_path    = translate("Path")
+    local t_nocerts = translate("No certificates found.")
     local cd="/etc/minigate/certs"
-    local h='<table class="table"><tr class="tr table-titles"><th class="th">域名</th><th class="th">过期时间</th><th class="th">路径</th></tr>'
+    local h='<table class="table"><tr class="tr table-titles"><th class="th">'..t_domain..'</th><th class="th">'..t_expires..'</th><th class="th">'..t_path..'</th></tr>'
     local found=false
     if fs.dir(cd)then
         for entry in fs.dir(cd)do
@@ -46,41 +49,65 @@ o.cfgvalue=function()
             end
         end
     end
-    if not found then h=h..'<tr class="tr"><td class="td" colspan="3" style="text-align:center;color:#999;padding:15px">暂无证书</td></tr>' end
+    if not found then h=h..'<tr class="tr"><td class="td" colspan="3" style="text-align:center;color:#999;padding:15px">'..t_nocerts..'</td></tr>' end
     return h..'</table>'
 end
 
-o=s:option(DummyValue,"_ast","acme.sh 状态"); o.rawhtml=true
+o=s:option(DummyValue,"_ast", translate("acme.sh status")); o.rawhtml=true
 o.cfgvalue=function()
-    if fs.access("/etc/minigate/acme/data/acme.sh")and fs.access("/etc/minigate/acme/data/dnsapi/dns_cf.sh")then return'<span style="color:#4caf50">&#10003; 已安装</span>'
-    elseif fs.access("/etc/minigate/acme/data/acme.sh")then return'<span style="color:#ff9800">&#9888; 缺DNS插件</span>'
-    else return'<span style="color:#f44336">&#10007; 未安装</span>'end
+    local t_installed   = translate("Installed")
+    local t_dnsmissing  = translate("DNS plugin missing")
+    local t_notinstalled= translate("Not installed")
+    if fs.access("/etc/minigate/acme/data/acme.sh")and fs.access("/etc/minigate/acme/data/dnsapi/dns_cf.sh")then return'<span style="color:#4caf50">&#10003; '..t_installed..'</span>'
+    elseif fs.access("/etc/minigate/acme/data/acme.sh")then return'<span style="color:#ff9800">&#9888; '..t_dnsmissing..'</span>'
+    else return'<span style="color:#f44336">&#10007; '..t_notinstalled..'</span>'end
 end
 
--- 操作
-s=m:section(NamedSection,"acme","acme","操作"); s.anonymous=true
+s=m:section(NamedSection,"acme","acme", translate("Actions")); s.anonymous=true
 o=s:option(DummyValue,"_act"," "); o.rawhtml=true
 o.cfgvalue=function()
     local iu=luci.dispatcher.build_url("admin/services/minigate/acme_install")
     local su=luci.dispatcher.build_url("admin/services/minigate/acme_issue")
+    local t_dl_install   = translate("Download and install acme.sh")
+    local t_issue_domain = translate("Issue domain:")
+    local t_cfg_ddns     = translate("Configure Dynamic DNS first")
+    local t_issue_renew  = translate("Issue / Renew")
+    local t_processing   = translate("Processing...")
+    local t_dl_ing       = translate("Downloading and installing (about 30 seconds)...")
+    local t_sel_domain   = translate("Please select a domain")
+    local t_timeout      = translate("Timeout")
+    local t_failed       = translate("Failed")
+    local t_issuing = translate("Issuing") .. " "
     local opts=""
     for _,d in ipairs(dd)do opts=opts..'<option value="'..d..'">'..d..'</option>' end
-    return[[
-<div style="margin-bottom:15px"><button class="cbi-button cbi-button-reload" id="bi" onclick="doI()" style="min-width:220px">下载并安装 acme.sh</button></div>
+    local sel_opts = opts~="" and opts or ('<option value="">'..t_cfg_ddns..'</option>')
+    return [[
+<div style="margin-bottom:15px">
+<button class="cbi-button cbi-button-reload" id="bi" onclick="doI()" style="min-width:220px">]] .. t_dl_install .. [[</button>
+</div>
 <div style="display:flex;gap:10px;align-items:center;flex-wrap:wrap;margin-bottom:10px">
-<label>签发域名：</label>
-<select id="sd" style="padding:5px 10px;border-radius:4px;border:1px solid #ccc;min-width:250px">]]..
-(opts~=""and opts or'<option value="">请先配置动态DNS</option>')..[[</select>
-<button class="cbi-button cbi-button-apply" id="bs" onclick="doS()">立即签发 / 续期</button></div>
-<div id="ap" style="margin-top:12px;display:none"><div style="background:#f0f0f0;border-radius:4px;padding:10px 15px;font-size:13px"><span style="display:inline-block;animation:sp 1s linear infinite;margin-right:8px">&#9203;</span><span id="am">处理中...</span></div></div>
-<div id="ar" style="margin-top:12px;display:none"><div id="ai" style="border-radius:4px;padding:10px 15px;font-size:13px"></div></div>
+<label>]] .. t_issue_domain .. [[</label>
+<select id="sd" style="padding:5px 10px;border-radius:4px;border:1px solid #ccc;min-width:250px">
+]] .. sel_opts .. [[
+</select>
+<button class="cbi-button cbi-button-apply" id="bs" onclick="doS()">]] .. t_issue_renew .. [[</button>
+</div>
+<div id="ap" style="margin-top:12px;display:none">
+  <div style="background:#f0f0f0;border-radius:4px;padding:10px 15px;font-size:13px">
+    <span style="display:inline-block;animation:sp 1s linear infinite;margin-right:8px">&#9203;</span>
+    <span id="am">]] .. t_processing .. [[</span>
+  </div>
+</div>
+<div id="ar" style="margin-top:12px;display:none">
+  <div id="ai" style="border-radius:4px;padding:10px 15px;font-size:13px"></div>
+</div>
 <style>@keyframes sp{from{transform:rotate(0deg)}to{transform:rotate(360deg)}}</style>
 <script type="text/javascript">
 function sP(m){document.getElementById('ap').style.display='block';document.getElementById('ar').style.display='none';document.getElementById('am').textContent=m}
 function sR(ok,m){document.getElementById('ap').style.display='none';document.getElementById('ar').style.display='block';var e=document.getElementById('ai');e.style.background=ok?'#e8f5e9':'#ffebee';e.style.color=ok?'#2e7d32':'#c62828';e.textContent=m}
-function doI(){document.getElementById('bi').disabled=true;sP('下载安装中（约30秒）...');XHR.get(']]..iu..[[',null,function(x,d){document.getElementById('bi').disabled=false;d?sR(d.success,d.message):sR(false,'失败');if(d&&d.success)setTimeout(function(){location.reload()},2000)})}
-function doS(){var d=document.getElementById('sd').value;if(!d){sR(false,'请选择域名');return}document.getElementById('bs').disabled=true;sP('签发 '+d+'（约1-2分钟）...');XHR.get(']]..su..[[',{domain:d},function(x,r){document.getElementById('bs').disabled=false;r?sR(r.success,r.message):sR(false,'超时');if(r&&r.success)setTimeout(function(){location.reload()},2000)})}
-</script>]]
-end
+function doI(){document.getElementById('bi').disabled=true;sP(']] .. t_dl_ing .. [[');XHR.get(']] .. iu .. [[',null,function(x,d){document.getElementById('bi').disabled=false;d?sR(d.success,d.message):sR(false,']] .. t_failed .. [[');if(d&&d.success)setTimeout(function(){location.reload()},2000)})}
+function doS(){var d=document.getElementById('sd').value;if(!d){sR(false,']] .. t_sel_domain .. [[');return}document.getElementById('bs').disabled=true;sP(']] .. t_issuing .. [['+d+' (~2min)');XHR.get(']] .. su .. [[',{domain:d},function(x,r){document.getElementById('bs').disabled=false;r?sR(r.success,r.message):sR(false,']] .. t_timeout .. [[');if(r&&r.success)setTimeout(function(){location.reload()},2000)})}
+</script>
+]] end
 
 return m

--- a/luasrc/model/cbi/minigate/ddns.lua
+++ b/luasrc/model/cbi/minigate/ddns.lua
@@ -1,7 +1,7 @@
 local m,s,o
 local sys=require"luci.sys"
 
-m=Map("minigate","MiniGate - 动态DNS","支持多域名、IPv4/IPv6双栈。保存后立即同步。需先启用全局开关。")
+m=Map("minigate", translate("MiniGate - Dynamic DNS"), translate("Supports multiple domains and IPv4/IPv6 dual-stack. Syncs immediately after save. Requires global switch to be enabled."))
 
 m.on_after_commit=function(self)
     sys.call("/bin/sh /usr/lib/minigate/ddns.sh force >/dev/null 2>&1 &")
@@ -9,67 +9,61 @@ m.on_after_commit=function(self)
     if en=="1"then sys.call("/etc/init.d/minigate restart >/dev/null 2>&1 &") end
 end
 
-s=m:section(TypedSection,"ddns","DDNS 记录")
+s=m:section(TypedSection,"ddns", translate("DDNS Records"))
 s.anonymous=true; s.addremove=true; s.sortable=true
 
-o=s:option(Flag,"enabled","启用"); o.rmempty=false
+o=s:option(Flag,"enabled", translate("Enable")); o.rmempty=false
 
-o=s:option(Value,"domain","域名"); o.rmempty=false; o.placeholder="*.example.com 或 home.example.com"
+o=s:option(Value,"domain", translate("Domain")); o.rmempty=false; o.placeholder="*.example.com or home.example.com"
 
-o=s:option(Value,"cf_zone_id","Zone ID"); o.rmempty=false; o.placeholder="Cloudflare 区域 ID"
+o=s:option(Value,"cf_zone_id","Zone ID"); o.rmempty=false; o.placeholder="Cloudflare Zone ID"
 
-o=s:option(Value,"cf_api_token","API 令牌"); o.rmempty=false; o.password=true
+o=s:option(Value,"cf_api_token", translate("API Token")); o.rmempty=false; o.password=true
 
--- ====== 协议版本 ======
-o=s:option(ListValue,"ip_version","协议版本")
-o:value("ipv4","仅 IPv4（A 记录）")
-o:value("ipv6","仅 IPv6（AAAA 记录）")
-o:value("dual","双栈（A + AAAA）")
+o=s:option(ListValue,"ip_version", translate("IP Version"))
+o:value("ipv4", translate("IPv4 only (A record)"))
+o:value("ipv6", translate("IPv6 only (AAAA record)"))
+o:value("dual", translate("Dual-stack (A + AAAA)"))
 o.default="ipv4"
-o.description="选择更新哪种 DNS 记录。双栈模式同时更新 A 和 AAAA 记录。"
+o.description= translate("Select which DNS record type to update. Dual-stack updates both A and AAAA records.")
 
-o=s:option(ListValue,"ip_source","IP 来源")
-o:value("interface","从网卡获取"); o:value("url","从外部URL获取"); o.default="interface"
+o=s:option(ListValue,"ip_source", translate("IP Source"))
+o:value("interface", translate("From network interface")); o:value("url", translate("From external URL")); o.default="interface"
 
--- IPv4 网卡
-o=s:option(ListValue,"interface","IPv4 网络接口"); o.default="wan"
+o=s:option(ListValue,"interface", translate("IPv4 network interface")); o.default="wan"
 local uci=require"luci.model.uci".cursor()
 uci:foreach("network","interface",function(sec) if sec[".name"]~="loopback"then o:value(sec[".name"],sec[".name"])end end)
 o:depends("ip_source","interface")
 
--- IPv4 URL
-o=s:option(ListValue,"ip_url","IPv4 获取地址")
+o=s:option(ListValue,"ip_url", translate("IPv4 detection URL"))
 o:value("http://ip.3322.net","ip.3322.net")
 o:value("http://members.3322.org/dyndns/getip","members.3322.org")
-o:value("http://ns1.dnspod.net:6666","ns1.dnspod.net (腾讯)")
-o:value("http://ip.tool.chinaz.com/getip","chinaz.com (站长工具)")
+o:value("http://ns1.dnspod.net:6666","ns1.dnspod.net (Tencent)")
+o:value("http://ip.tool.chinaz.com/getip","chinaz.com")
 o.default="http://ip.3322.net"
-o.description="旁路由/代理环境自动绕过代理直连获取真实公网IP"
+o.description= translate("In NAT/proxy environments, bypasses proxy to get the real public IP.")
 o:depends("ip_source","url")
 
--- IPv6 网卡
-o=s:option(ListValue,"interface6","IPv6 网络接口"); o.default="wan6"
-o.description="用于获取 IPv6 地址的接口（通常为 wan6）"
+o=s:option(ListValue,"interface6", translate("IPv6 network interface")); o.default="wan6"
+o.description= translate("Interface used to obtain the IPv6 address (usually wan6).")
 uci:foreach("network","interface",function(sec) if sec[".name"]~="loopback"then o:value(sec[".name"],sec[".name"])end end)
 o:depends({ip_source="interface",ip_version="ipv6"})
 o:depends({ip_source="interface",ip_version="dual"})
 
--- IPv6 URL
-o=s:option(ListValue,"ip_url6","IPv6 获取地址")
+o=s:option(ListValue,"ip_url6", translate("IPv6 detection URL"))
 o:value("https://api6.ipify.org","api6.ipify.org")
 o:value("https://6.ipw.cn","6.ipw.cn")
 o:value("https://v6.ident.me","v6.ident.me")
 o:value("https://ifconfig.co","ifconfig.co (v6)")
 o:value("http://v6.66666.host:66/ip","v6.66666.host")
 o.default="https://api6.ipify.org"
-o.description="仅通过 IPv6 连接获取地址"
+o.description= translate("Fetches address via IPv6-only connection.")
 o:depends({ip_source="url",ip_version="ipv6"})
 o:depends({ip_source="url",ip_version="dual"})
 
-o=s:option(Value,"check_interval","间隔(秒)"); o.datatype="uinteger"; o.default="300"
+o=s:option(Value,"check_interval", translate("Interval (seconds)")); o.datatype="uinteger"; o.default="300"
 
--- 状态+手动同步
-o=s:option(DummyValue,"_info","运行状态"); o.rawhtml=true
+o=s:option(DummyValue,"_info", translate("Status")); o.rawhtml=true
 o.cfgvalue=function(self,section)
     local st=m.uci:get("minigate",section,"status")or"unknown"
     local msg=m.uci:get("minigate",section,"status_msg")or""
@@ -78,35 +72,43 @@ o.cfgvalue=function(self,section)
     local lu=m.uci:get("minigate",section,"last_update")or""
     local ns=m.uci:get("minigate",section,"next_sync")or""
     local ver=m.uci:get("minigate",section,"ip_version")or"ipv4"
+    local t_partial   = translate("Partial")
+    local t_error     = translate("Error")
+    local t_notsynced = translate("Not synced")
+    local t_updated   = translate("Updated: ")
+    local t_next      = translate("Next: ")
+    local t_syncnow   = translate("Sync now")
 
     local h=""
     if st=="ok"then
-        h='<span style="color:#4caf50">&#10003; 正常</span>'
+        h='<span style="color:#4caf50">&#10003; OK</span>'
     elseif st=="partial"then
-        h='<span style="color:#ff9800">&#9888; 部分成功</span>'
+        h='<span style="color:#ff9800">&#9888; '..t_partial..'</span>'
     elseif st=="error"then
-        h='<span style="color:#f44336">&#10007; '..(msg~=""and msg or"异常")..'</span>'
-    else h='<span style="color:#999">未同步</span>' end
+        h='<span style="color:#f44336">&#10007; '..(msg~=""and msg or t_error)..'</span>'
+    else h='<span style="color:#999">'..t_notsynced..'</span>' end
 
-    -- 显示 IP 地址
     if ip~=""then h=h..'<br><span style="font-size:11px;color:#888">A: '..ip..'</span>' end
     if ip6~=""then h=h..'<br><span style="font-size:11px;color:#2196f3">AAAA: '..ip6..'</span>' end
     if msg~=""and st~="error"then h=h..'<br><span style="font-size:11px;color:#888">'..msg..'</span>' end
-    if lu~=""then h=h..'<br><span style="font-size:11px;color:#888">更新: '..lu..'</span>' end
-    if ns~=""then h=h..'<br><span style="font-size:11px;color:#888">下次: '..ns..'</span>' end
+    if lu~=""then h=h..'<br><span style="font-size:11px;color:#888">'..t_updated..lu..'</span>' end
+    if ns~=""then h=h..'<br><span style="font-size:11px;color:#888">'..t_next..ns..'</span>' end
 
     h=h..'<br><button class="cbi-button cbi-button-action" style="margin-top:4px;font-size:12px;padding:2px 10px" '
-    h=h..'onclick="doSync(\''..section..'\',this)">手动同步</button>'
+    h=h..'onclick="doSync(\''..section..'\',this)">'..t_syncnow..'</button>'
     h=h..'<span id="sr-'..section..'" style="margin-left:8px;font-size:12px"></span>'
     return h
 end
 
--- 注入 JS
+-- Inject JS
 s=m:section(NamedSection,"global","global"); s.anonymous=true
 o=s:option(DummyValue,"_js"," "); o.rawhtml=true
 o.cfgvalue=function()
     local url=luci.dispatcher.build_url("admin/services/minigate/ddns_sync")
-    return'<script type="text/javascript">function doSync(s,b){b.disabled=true;b.textContent="同步中...";var e=document.getElementById("sr-"+s);e.textContent="";XHR.get("'..url..'",{section:s},function(x,d){b.disabled=false;b.textContent="手动同步";if(d&&d.success){e.innerHTML=\'<span style="color:#4caf50">\\u2713 \'+d.ip+(d.ip6?\' / \'+d.ip6:\'\')+\'</span>\';setTimeout(function(){location.reload()},1500)}else e.innerHTML=\'<span style="color:#f44336">\\u2717 失败</span>\'})}</script>'
+    local t_syncing = translate("Syncing...")
+    local t_syncnow = translate("Sync now")
+    local t_failed  = translate("Failed")
+    return '<script type="text/javascript">function doSync(s,b){b.disabled=true;b.textContent="'..t_syncing..'";var e=document.getElementById("sr-"+s);e.textContent="";XHR.get("'..url..'",{section:s},function(x,d){b.disabled=false;b.textContent="'..t_syncnow..'";if(d&&d.success){e.innerHTML=\'<span style="color:#4caf50">\\u2713 \'+d.ip+(d.ip6?\' / \'+d.ip6:\'\')+\'</span>\';setTimeout(function(){location.reload()},1500)}else e.innerHTML=\'<span style="color:#f44336">\\u2717 '..t_failed..'</span>\'})}</script>'
 end
 
 return m

--- a/luasrc/model/cbi/minigate/general.lua
+++ b/luasrc/model/cbi/minigate/general.lua
@@ -1,7 +1,7 @@
 local m, s, o
 local sys = require "luci.sys"
 
-m = Map("minigate", "MiniGate 轻网关", "轻量级网关管理：动态域名解析（IPv4/IPv6双栈）、SSL 证书签发、反向代理。")
+m = Map("minigate", translate("MiniGate Gateway"), translate("Lightweight gateway management: DDNS (IPv4/IPv6 dual-stack), SSL certificate issuance, reverse proxy."))
 
 m.on_after_commit = function(self)
     local en = self.uci:get("minigate", "global", "enabled")
@@ -12,9 +12,9 @@ m.on_after_commit = function(self)
     end
 end
 
-s = m:section(NamedSection, "global", "global", "服务状态")
+s = m:section(NamedSection, "global", "global", translate("Service Status"))
 s.anonymous = true
-s:tab("status", "总览")
+s:tab("status", translate("Overview"))
 
 local su = luci.dispatcher.build_url("admin/services/minigate/status")
 
@@ -24,6 +24,33 @@ o.cfgvalue = function()
     local su = luci.dispatcher.build_url("admin/services/minigate/status")
     local au = luci.dispatcher.build_url("admin/services/minigate/proxy_access")
     local gu = luci.dispatcher.build_url("admin/services/minigate/geo_lookup")
+    local t_ddns     = translate("Dynamic DNS")
+    local t_cert     = translate("SSL/TLS Certificate")
+    local t_proxy    = translate("Reverse Proxy")
+    local t_accesslog = translate("Access Log")
+    local t_show     = translate("Show")
+    local t_status   = translate("Status")
+    local t_ip       = translate("IP Address")
+    local t_loc      = translate("Location")
+    local t_last     = translate("Last Visit")
+    local t_domain   = translate("Domain")
+    local t_count    = translate("Count")
+    local t_loading  = translate("Loading...")
+    local t_norecord = translate("No access records yet.")
+    local t_online   = translate("Online")
+    local t_offline  = translate("Offline")
+    local t_querying = translate("Querying...")
+    local t_notcfg   = translate("Not configured")
+    local t_disabled = translate("Disabled")
+    local t_stopped  = translate("Stopped")
+    local t_expires  = translate("Expires: ")
+    local t_updated  = translate("Updated: ")
+    local t_next     = translate("Next: ")
+    local t_nginxrun = translate("Nginx running")
+    local t_running  = translate("Running")
+    local t_valid    = translate("Valid")
+    local t_partial  = translate("Partial")
+    local t_error_s  = translate("Error")
     return [[
 <style>
 .mg-wrap{display:flex;flex-direction:column;gap:16px}
@@ -76,17 +103,17 @@ o.cfgvalue = function()
 <div class="mg-wrap">
 <div id="mg" class="mg-status-grid">
 <div id="mg-ddns-card" class="mg-card" style="--accent:#4caf50">
-<div class="mg-card-title">动态 DNS</div>
+<div class="mg-card-title">]] .. t_ddns .. [[</div>
 <div id="mg-d1" class="mg-card-state">--</div>
 <div id="mg-d2" class="mg-card-body"></div>
 </div>
 <div id="mg-cert-card" class="mg-card" style="--accent:#2196f3">
-<div class="mg-card-title">SSL/TLS 证书</div>
+<div class="mg-card-title">]] .. t_cert .. [[</div>
 <div id="mg-a1" class="mg-card-state">--</div>
 <div id="mg-a2" class="mg-card-body"></div>
 </div>
 <div id="mg-proxy-card" class="mg-card" style="--accent:#ff9800">
-<div class="mg-card-title">反向代理</div>
+<div class="mg-card-title">]] .. t_proxy .. [[</div>
 <div id="mg-p1" class="mg-card-state">--</div>
 <div id="mg-p2" class="mg-card-body"></div>
 </div>
@@ -94,15 +121,15 @@ o.cfgvalue = function()
 
 <div id="mg-visitors" class="mg-panel">
 <div class="mg-panel-head">
-<div class="mg-panel-title">访问记录 <span id="mg-v-count" class="mg-count"></span></div>
-<label class="mg-limit-label">显示
+<div class="mg-panel-title">]] .. t_accesslog .. [[ <span id="mg-v-count" class="mg-count"></span></div>
+<label class="mg-limit-label">]] .. t_show .. [[
 <select id="mg-v-limit" class="mg-select">
 <option value="5" selected>5</option>
 <option value="20">20</option>
 <option value="50">50</option>
-</select>条</label>
+</select></label>
 </div>
-<div id="mg-v-list" class="mg-table-wrap"><div class="mg-empty">加载中...</div></div>
+<div id="mg-v-list" class="mg-table-wrap"><div class="mg-empty">]] .. t_loading .. [[</div></div>
 </div>
 </div>
 
@@ -126,7 +153,7 @@ function queryGeo(ip,cb){
     }
     _geoPending[ip]=[cb];
     XHR.get(']] .. gu .. [[',{ip:ip},function(x,d){
-        var loc=(d&&d.geo)?d.geo:'未知';
+        var loc=(d&&d.geo)?d.geo:'Unknown';
         var list=_geoPending[ip]||[];
         delete _geoPending[ip];
         _geoCache[ip]=loc;
@@ -139,23 +166,23 @@ function loadVisitors(){
         var el=document.getElementById('mg-v-list');
         var ct=document.getElementById('mg-v-count');
         if(!d||!d.visitors||d.visitors.length===0){
-            el.innerHTML='<div class="mg-empty">暂无访问记录</div>';
+            el.innerHTML='<div class="mg-empty">]] .. t_norecord .. [[</div>';
             ct.textContent='';
             return;
         }
-        ct.textContent='('+d.visitors.length+' 个IP)';
+        ct.textContent=d.visitors&&d.visitors.length?'('+d.visitors.length+' IPs)':'';
         var h='<table class="mg-table">';
-        h+='<thead><tr><th>状态</th><th>IP 地址</th><th>归属地</th><th>最后访问</th><th>域名</th><th>次数</th></tr></thead><tbody>';
+        h+='<thead><tr><th>]] .. t_status .. [[</th><th>]] .. t_ip .. [[</th><th>]] .. t_loc .. [[</th><th>]] .. t_last .. [[</th><th>]] .. t_domain .. [[</th><th>]] .. t_count .. [[</th></tr></thead><tbody>';
         for(var i=0;i<d.visitors.length;i++){
             var v=d.visitors[i];
             var dot=v.online
-                ?'<span class="mg-dot on" title="在线"></span>'
-                :'<span class="mg-dot" title="离线"></span>';
-            var stxt=v.online?'<span style="color:#72d987">在线</span>':'<span style="color:#a6a6a6">离线</span>';
+                ?'<span class="mg-dot on" title="]] .. t_online .. [["></span>'
+                :'<span class="mg-dot" title="]] .. t_offline .. [["></span>';
+            var stxt=v.online?'<span style="color:#72d987">]] .. t_online .. [[</span>':'<span style="color:#a6a6a6">]] .. t_offline .. [[</span>';
             h+='<tr>';
             h+='<td><span class="mg-status">'+dot+stxt+'</span></td>';
             h+='<td><code class="mg-ip">'+v.ip+'</code></td>';
-            h+='<td id="geo-'+i+'"><span style="color:#999">查询中...</span></td>';
+            h+='<td id="geo-'+i+'"><span style="color:#999">]] .. t_querying .. [[</span></td>';
             h+='<td style="white-space:nowrap">'+fmtT(v.last_time)+'</td>';
             h+='<td>'+v.domain+'</td>';
             h+='<td>'+v.count+'</td>';
@@ -195,7 +222,7 @@ var card=document.getElementById('mg-ddns-card');
 if(d.ddns_list&&d.ddns_list.length>0){
 var e=d.ddns_list[0];
 var c=e.status=='ok'?'#4caf50':(e.status=='partial'?'#ff9800':(e.enabled=='1'?'#f44336':'#999'));
-var l=e.status=='ok'?'\u2713 \u8fd0\u884c\u4e2d':(e.status=='partial'?'\u26a0 \u90e8\u5206\u6210\u529f':(e.enabled=='1'?'\u26a0 \u5f02\u5e38':'\u672a\u542f\u7528'));
+var l=e.status=='ok'?'\u2713 ]] .. t_running .. [[':(e.status=='partial'?'\u26a0 ]] .. t_partial .. [[':(e.enabled=='1'?'\u26a0 ]] .. t_error_s .. [[':']] .. t_disabled .. [['));
 card.style.setProperty('--accent',c);
 d1.innerHTML='<span style="color:'+c+'">'+l+'</span>';
 var info=(e.domain||'')+'\n';
@@ -208,20 +235,20 @@ if(sm){
     var onlyIpStatus=sm.replace(/A:[^;]+;?/g,'').replace(/AAAA:[^;]+;?/g,'').replace(/\s+/g,'')=='';
     if(!(onlyIpStatus&&(dupA||dupAAAA)))info+=sm+'\n';
 }
-if(e.last_update)info+='\u66f4\u65b0: '+e.last_update+'\n';
-if(e.next_sync)info+='\u4e0b\u6b21: '+e.next_sync;
-if(d.ddns_list.length>1)info+='\n(+'+(d.ddns_list.length-1)+' \u6761\u8bb0\u5f55)';
+if(e.last_update)info+=']] .. t_updated .. [[\u200b'+e.last_update+'\n';
+if(e.next_sync)info+=']] .. t_next .. [[\u200b'+e.next_sync;
+if(d.ddns_list.length>1)info+='\n(+'+(d.ddns_list.length-1)+' more)';
 d2.innerHTML=info.replace(/\n/g,'<br>');
-}else{d1.innerHTML='<span style="color:#999">\u672a\u914d\u7f6e</span>';d2.textContent='';card.style.setProperty('--accent','#777');}
+}else{d1.innerHTML='<span style="color:#999">]] .. t_notcfg .. [[</span>';d2.textContent='';card.style.setProperty('--accent','#777');}
 
 var a1=document.getElementById('mg-a1'),a2=document.getElementById('mg-a2');
 if(d.acme&&d.acme.enabled=='1'){
-a1.innerHTML=d.acme.status=='ok'?'<span style="color:#2196f3">\u2713 \u6709\u6548</span>':'<span style="color:#f44336">'+d.acme.status+'</span>';
-a2.innerHTML=(d.acme.last_domain||'')+(d.acme.cert_expiry?'<br>\u8fc7\u671f: '+d.acme.cert_expiry:'');
-}else{a1.innerHTML='<span style="color:#999">\u672a\u542f\u7528</span>';a2.textContent='';}
+a1.innerHTML=d.acme.status=='ok'?'<span style="color:#2196f3">\u2713 ]] .. t_valid .. [[</span>':'<span style="color:#f44336">'+d.acme.status+'</span>';
+a2.innerHTML=(d.acme.last_domain||'')+(d.acme.cert_expiry?'<br>]] .. t_expires .. [[\u200b'+d.acme.cert_expiry:'');
+}else{a1.innerHTML='<span style="color:#999">]] .. t_disabled .. [[</span>';a2.textContent='';}
 
 var p1=document.getElementById('mg-p1'),p2=document.getElementById('mg-p2');
-p1.innerHTML=d.proxy_running?'<span style="color:#ff9800">\u2713 \u8fd0\u884c\u4e2d</span>':'<span style="color:#999">\u5df2\u505c\u6b62</span>';
+p1.innerHTML=d.proxy_running?'<span style="color:#ff9800">\u2713 ]] .. t_running .. [[</span>':'<span style="color:#999">]] .. t_stopped .. [[</span>';
 var pinfo='';
 if(d.proxy_rules&&d.proxy_rules.length>0){
 for(var i=0;i<d.proxy_rules.length;i++){
@@ -229,7 +256,7 @@ var r=d.proxy_rules[i];
 var url=r.scheme+'://'+r.domain+(r.listen_port!='443'&&r.listen_port!='80'?':'+r.listen_port:'');
 var v6tag=r.ipv6_listen=='1'?' <span style="color:#2196f3;font-size:10px">[IPv6]</span>':'';
 pinfo+='<div><span class="mg-link">'+url+'</span>'+v6tag+' \u2192 '+r.target+'</div>';
-}}else if(d.proxy_running){pinfo='Nginx \u8fd0\u884c\u4e2d';}
+}}else if(d.proxy_running){pinfo=']] .. t_nginxrun .. [[';}
 p2.innerHTML=pinfo;
 });
 
@@ -238,14 +265,14 @@ setInterval(loadVisitors,15000);
 </script>
 ]] end
 
-s = m:section(NamedSection, "global", "global", "全局设置")
+s = m:section(NamedSection, "global", "global", translate("Global Settings"))
 s.anonymous = true
-o = s:option(Flag, "enabled", "启用 MiniGate")
-o.description = "总开关。关闭后停止 DDNS 定时任务、ACME 续期和反向代理。保存后立即生效。"
+o = s:option(Flag, "enabled", translate("Enable MiniGate"))
+o.description = translate("Master switch. Disabling stops DDNS cron, ACME renewal and reverse proxy. Takes effect immediately after save.")
 o.rmempty = false
 
-o = s:option(Flag, "ipv6_listen", "反向代理监听 IPv6")
-o.description = "开启后，Nginx 反向代理将同时监听 IPv4 和 IPv6 地址（listen [::]:port）。"
+o = s:option(Flag, "ipv6_listen", translate("Reverse proxy listen on IPv6"))
+o.description = translate("When enabled, Nginx reverse proxy also listens on IPv6 (listen [::]:port).")
 o.rmempty = false
 o.default = "0"
 

--- a/luasrc/model/cbi/minigate/login_guard.lua
+++ b/luasrc/model/cbi/minigate/login_guard.lua
@@ -2,16 +2,16 @@ local m, s, o
 local sys = require "luci.sys"
 local fs = require "nixio.fs"
 
-m = Map("minigate", "登录防护 (Login Guard)",
-    "监控 SSH（dropbear）和 LuCI 网页登录失败，达到阈值自动封禁源 IP。" ..
-    "适用于 SSH 端口被映射到公网、防爆破。LAN 私有 IP 自动豁免。")
+m = Map("minigate", translate("Login Guard"),
+    translate("Monitors SSH (dropbear) and LuCI login failures and auto-bans source IPs on threshold.") ..
+    " " .. translate("Intended for SSH ports exposed to the internet. LAN private IPs are always exempt."))
 
 m.on_after_commit = function(self)
     sys.call("/etc/init.d/minigate reload >/dev/null 2>&1 &")
 end
 
 -- ============== 实时状态 ==============
-s = m:section(NamedSection, "login_guard", "login_guard", "实时状态")
+s = m:section(NamedSection, "login_guard", "login_guard", translate("Live Status"))
 s.anonymous = true
 
 local lu = luci.dispatcher.build_url("admin/services/minigate/lg_status")
@@ -23,6 +23,37 @@ local gu = luci.dispatcher.build_url("admin/services/minigate/geo_lookup")
 o = s:option(DummyValue, "_dash")
 o.rawhtml = true
 o.cfgvalue = function()
+    local t_svc_status   = translate("Service Status")
+    local t_cur_banned   = translate("Currently Banned")
+    local t_counting     = translate("Counting Failures")
+    local t_banned_list  = translate("Banned IP List")
+    local t_counting_sub = translate("Counting Failures (below threshold)")
+    local t_show         = translate("Show")
+    local t_enter_ip     = translate("Enter IP to ban")
+    local t_ban          = translate("Ban")
+    local t_flush_all    = translate("Flush All")
+    local t_loading      = translate("Loading...")
+    local t_ip_addr      = translate("IP Address")
+    local t_location     = translate("Location")
+    local t_failures     = translate("Failures")
+    local t_last_seen    = translate("Last Seen")
+    local t_since_first  = translate("Since First Failure")
+    local t_remaining    = translate("Remaining")
+    local t_action       = translate("Action")
+    local t_none         = translate("None")
+    local t_no_bans      = translate("No bans.")
+    local t_querying     = translate("Querying...")
+    local t_disabled     = translate("Disabled")
+    local t_running      = translate("Running")
+    local t_not_running  = translate("Not running")
+    local t_unban        = translate("Unban")
+    local t_confirm_unban= translate("Confirm unban")
+    local t_failed       = translate("Failed")
+    local t_please_ip    = translate("Please enter an IP")
+    local t_invalid_ip   = translate("Invalid IP format")
+    local t_confirm_flush= translate("Confirm flush all bans? This cannot be undone.")
+    local t_refresh_fail = translate("Refresh failed, please retry.")
+    local t_render_err   = translate("Render error: ")
     local function esc(v)
         v = tostring(v or "")
         v = v:gsub("&", "&amp;"):gsub("<", "&lt;"):gsub(">", "&gt;")
@@ -74,16 +105,16 @@ o.cfgvalue = function()
         local style = (i > 5) and ' style="display:none"' or ''
         watching_rows[#watching_rows + 1] =
             '<tr class="lg-watch-row" data-ip="' .. esc(item.ip) .. '" data-index="' .. tostring(i) .. '"' .. style .. '><td><code class="lg-ip">' .. esc(item.ip) .. '</code></td>' ..
-            '<td id="lg-watch-geo-initial-' .. tostring(i) .. '"><span style="color:#999">查询中...</span></td>' ..
+            '<td id="lg-watch-geo-initial-' .. tostring(i) .. '"><span style="color:#999">Querying...</span></td>' ..
             '<td><span style="font-weight:bold">' .. esc(item.count) .. ' / ' .. esc(threshold) .. '</span></td>' ..
             '<td>' .. esc(item.last_seen) .. '</td>' ..
             '<td>' .. esc(fmt_duration(item.age)) .. '</td></tr>'
     end
 
-    local initial_watching = '<div class="lg-empty">无</div>'
+    local initial_watching = '<div class="lg-empty">None</div>'
     if #watching_rows > 0 then
         initial_watching =
-            '<table class="lg-table"><thead><tr><th>IP 地址</th><th>归属地</th><th>失败次数</th><th>最近访问时间</th><th>距首次失败</th></tr></thead><tbody>' ..
+            '<table class="lg-table"><thead><tr><th>IP Address</th><th>Location</th><th>Failures</th><th>Last Seen</th><th>Since First Failure</th></tr></thead><tbody>' ..
             table.concat(watching_rows, "") ..
             '</tbody></table>'
     end
@@ -139,47 +170,47 @@ o.cfgvalue = function()
 <div class="lg-wrap">
 <div id="lg-summary" class="lg-summary">
   <div class="lg-card" style="--accent:#4caf50">
-    <div class="lg-card-title">服务状态</div>
+    <div class="lg-card-title">]] .. t_svc_status .. [[</div>
     <div id="lg-running" class="lg-card-value">--</div>
   </div>
   <div class="lg-card" style="--accent:#f44336">
-    <div class="lg-card-title">当前已封禁</div>
+    <div class="lg-card-title">]] .. t_cur_banned .. [[</div>
     <div id="lg-banned-count" class="lg-card-value" style="color:#ff7b72">--</div>
   </div>
   <div class="lg-card" style="--accent:#ff9800">
-    <div class="lg-card-title">失败计数中</div>
+    <div class="lg-card-title">]] .. t_counting .. [[</div>
     <div id="lg-watching-count" class="lg-card-value" style="color:#ffb35c">--</div>
   </div>
 </div>
 
 <div class="lg-panel">
   <div class="lg-panel-head">
-    <div class="lg-panel-title">已封禁 IP 列表</div>
+    <div class="lg-panel-title">]] .. t_banned_list .. [[</div>
     <div class="lg-tools">
-      <label class="lg-limit-label">显示
+      <label class="lg-limit-label">]] .. t_show .. [[
         <select id="lg-ban-limit" class="lg-select">
-          <option value="5">5 条</option>
-          <option value="20">20 条</option>
-          <option value="30">30 条</option>
+          <option value="5">5</option>
+          <option value="20">20</option>
+          <option value="30">30</option>
         </select>
       </label>
-      <input id="lg-ban-input" class="lg-input" type="text" placeholder="输入 IP 手动封禁" />
-      <button class="lg-btn lg-btn-primary" onclick="lgManualBan()">封禁</button>
-      <button class="lg-btn lg-btn-danger" onclick="lgFlushAll()">清空全部</button>
+      <input id="lg-ban-input" class="lg-input" type="text" placeholder="]] .. t_enter_ip .. [[" />
+      <button class="lg-btn lg-btn-primary" onclick="lgManualBan()">]] .. t_ban .. [[</button>
+      <button class="lg-btn lg-btn-danger" onclick="lgFlushAll()">]] .. t_flush_all .. [[</button>
     </div>
   </div>
-  <div id="lg-banned-list" class="lg-table-wrap"><div class="lg-empty">加载中...</div></div>
+  <div id="lg-banned-list" class="lg-table-wrap"><div class="lg-empty">]] .. t_loading .. [[</div></div>
 </div>
 
 <div class="lg-panel">
   <div class="lg-panel-head">
-    <div class="lg-panel-title">失败计数中（未达阈值）</div>
+    <div class="lg-panel-title">]] .. t_counting_sub .. [[</div>
     <div class="lg-tools">
-      <label class="lg-limit-label">显示
+      <label class="lg-limit-label">]] .. t_show .. [[
         <select id="lg-watch-limit" class="lg-select">
-          <option value="5">5 条</option>
-          <option value="20">20 条</option>
-          <option value="30">30 条</option>
+          <option value="5">5</option>
+          <option value="20">20</option>
+          <option value="30">30</option>
         </select>
       </label>
     </div>
@@ -203,7 +234,7 @@ function lgQueryGeo(ip,cb){
     }
     _lgGeoPending[ip]=[cb];
     XHR.get(']] .. gu .. [[',{ip:ip},function(x,d){
-        var loc=(d&&d.geo)?d.geo:'未知';
+        var loc=(d&&d.geo)?d.geo:']] .. translate('Unknown') .. [[';
         var list=_lgGeoPending[ip]||[];
         delete _lgGeoPending[ip];
         _lgGeoCache[ip]=loc;
@@ -244,28 +275,28 @@ function fmtDuration(s){
 }
 
 function lgUnban(ip,btn){
-    if(!confirm('确认解封 '+ip+' ?'))return;
+    if(!confirm(']] .. t_confirm_unban .. [[ '+ip+' ?'))return;
     btn.disabled=true; btn.textContent='...';
     XHR.get(']] .. uu .. [[',{ip:ip},function(x,d){
         if(d&&d.success){lgRefresh();}
-        else{btn.disabled=false;btn.textContent='解封';alert('失败');}
+        else{btn.disabled=false;btn.textContent=']] .. t_unban .. [[';alert(']] .. t_failed .. [[');}
     });
 }
 
 function lgManualBan(){
     var ip=document.getElementById('lg-ban-input').value.trim();
-    if(!ip){alert('请输入 IP');return;}
-    if(!ip.match(/^\d+\.\d+\.\d+\.\d+$/)){alert('IP 格式不对');return;}
+    if(!ip){alert(']] .. t_please_ip .. [[');return;}
+    if(!ip.match(/^\d+\.\d+\.\d+\.\d+$/)){alert(']] .. t_invalid_ip .. [[');return;}
     XHR.get(']] .. bu .. [[',{ip:ip},function(x,d){
         if(d&&d.success){
             document.getElementById('lg-ban-input').value='';
             lgRefresh();
-        }else alert('失败');
+        }else alert(']] .. t_failed .. [[');
     });
 }
 
 function lgFlushAll(){
-    if(!confirm('确认清空所有封禁？此操作不可撤销。'))return;
+    if(!confirm(']] .. t_confirm_flush .. [['))return;
     XHR.get(']] .. fu .. [[',null,function(x,d){
         if(d&&d.success)lgRefresh();
     });
@@ -277,11 +308,11 @@ function lgRenderWatching(watching,threshold){
     watching=watching||[];
     threshold=Number(threshold)||3;
     if(watching.length==0){
-        wEl.innerHTML='<div class="lg-empty">无</div>';
+        wEl.innerHTML='<div class="lg-empty">]] .. t_none .. [[</div>';
         return;
     }
     var h2='<table class="lg-table">';
-    h2+='<thead><tr><th>IP 地址</th><th>归属地</th><th>失败次数</th><th>最近访问时间</th><th>距首次失败</th></tr></thead><tbody>';
+    h2+='<thead><tr><th>]] .. t_ip_addr .. [[</th><th>]] .. t_location .. [[</th><th>]] .. t_failures .. [[</th><th>]] .. t_last_seen .. [[</th><th>]] .. t_since_first .. [[</th></tr></thead><tbody>';
     for(var j=0;j<watching.length;j++){
         var w=watching[j]||{};
         var ip=w.ip||'--';
@@ -292,7 +323,7 @@ function lgRenderWatching(watching,threshold){
         var color=pct>=66?'#ff7b72':(pct>=33?'#ffb35c':'#aaa');
         h2+='<tr>';
         h2+='<td><code class="lg-ip">'+ip+'</code></td>';
-        h2+='<td id="lg-watch-geo-'+j+'"><span style="color:#999">查询中...</span></td>';
+        h2+='<td id="lg-watch-geo-'+j+'"><span style="color:#999">]] .. t_querying .. [[</span></td>';
         h2+='<td><span style="color:'+color+';font-weight:bold">'+count+' / '+threshold+'</span></td>';
         h2+='<td>'+lastSeen+'</td>';
         h2+='<td>'+fmtDuration(age)+'</td>';
@@ -322,16 +353,16 @@ function lgRenderWatching(watching,threshold){
 function lgApplyStatus(d){
         if(!d){
             var wEl=document.getElementById('lg-watching-list');
-            if(wEl)wEl.innerHTML='<div class="lg-empty">刷新失败，请稍后再试</div>';
+            if(wEl)wEl.innerHTML='<div class="lg-empty">]] .. t_refresh_fail .. [[</div>';
             return;
         }
         // 服务状态
         var rEl=document.getElementById('lg-running');
         if(d.enabled=='1'){
-            if(d.running) rEl.innerHTML='<span style="color:#4caf50">✓ 运行中</span>';
-            else rEl.innerHTML='<span style="color:#f44336">✗ 未运行</span>';
+            if(d.running) rEl.innerHTML='<span style="color:#4caf50">&#10003; ]] .. t_running .. [[</span>';
+            else rEl.innerHTML='<span style="color:#f44336">&#10007; ]] .. t_not_running .. [[</span>';
         }else{
-            rEl.innerHTML='<span style="color:#999">未启用</span>';
+            rEl.innerHTML='<span style="color:#999">]] .. t_disabled .. [[</span>';
         }
         document.getElementById('lg-banned-count').textContent=(d.banned_total!=null)?d.banned_total:(d.banned||[]).length;
         document.getElementById('lg-watching-count').textContent=(d.watching_total!=null)?d.watching_total:(d.watching||[]).length;
@@ -339,17 +370,17 @@ function lgApplyStatus(d){
         // 已封禁列表
         var listEl=document.getElementById('lg-banned-list');
         if(!d.banned||d.banned.length==0){
-            listEl.innerHTML='<div class="lg-empty">暂无封禁</div>';
+            listEl.innerHTML='<div class="lg-empty">]] .. t_no_bans .. [[</div>';
         }else{
             var h='<table class="lg-table">';
-            h+='<thead><tr><th>IP 地址</th><th>归属地</th><th>剩余时间</th><th>操作</th></tr></thead><tbody>';
+            h+='<thead><tr><th>]] .. t_ip_addr .. [[</th><th>]] .. t_location .. [[</th><th>]] .. t_remaining .. [[</th><th>]] .. t_action .. [[</th></tr></thead><tbody>';
             for(var i=0;i<d.banned.length;i++){
                 var b=d.banned[i];
                 h+='<tr>';
                 h+='<td><code class="lg-ip lg-ip-danger">'+b.ip+'</code></td>';
-                h+='<td id="lg-geo-'+i+'"><span style="color:#999">查询中...</span></td>';
+                h+='<td id="lg-geo-'+i+'"><span style="color:#999">]] .. t_querying .. [[</span></td>';
                 h+='<td>'+fmtDuration(b.remaining)+'</td>';
-                h+='<td><button class="lg-unban" onclick="lgUnban(\''+b.ip+'\',this)">解封</button></td>';
+                h+='<td><button class="lg-unban" onclick="lgUnban(\''+b.ip+'\',this)">]] .. t_unban .. [[</button></td>';
                 h+='</tr>';
             }
             h+='</tbody></table>';
@@ -371,7 +402,7 @@ function lgApplyStatus(d){
         try{lgRenderWatching(d.watching,d.threshold);}
         catch(e){
             var wEl=document.getElementById('lg-watching-list');
-            if(wEl)wEl.innerHTML='<div class="lg-empty">渲染失败：'+e.message+'</div>';
+            if(wEl)wEl.innerHTML='<div class="lg-empty">]] .. t_render_err .. [['+e.message+'</div>';
         }
 
 }
@@ -412,41 +443,40 @@ setInterval(lgRefresh,8000);
 ]]
 end
 
--- ============== 设置 ==============
-s = m:section(NamedSection, "login_guard", "login_guard", "设置")
+s = m:section(NamedSection, "login_guard", "login_guard", translate("Settings"))
 s.anonymous = true
 
-o = s:option(Flag, "enabled", "启用登录防护")
-o.description = "开启后将自动监控 SSH/LuCI 失败登录。LAN IP 永远不会被封禁。"
+o = s:option(Flag, "enabled", translate("Enable Login Guard"))
+o.description = translate("When enabled, SSH/LuCI login failures are monitored. LAN IPs are never banned.")
 o.rmempty = false
 
-o = s:option(Value, "threshold", "失败次数阈值")
-o.description = "在「失败窗口」时间内累积达到此次数则封禁。"
+o = s:option(Value, "threshold", translate("Failure threshold"))
+o.description = translate("Number of failures within the window that triggers a ban.")
 o.datatype = "uinteger"
 o.default = "3"
 o.placeholder = "3"
 
-o = s:option(ListValue, "window", "失败窗口（秒）")
-o.description = "在多长时间内累计失败次数。超过此时间未再失败则计数清零。"
-o:value("300", "5 分钟")
-o:value("600", "10 分钟")
-o:value("1800", "30 分钟")
-o:value("3600", "1 小时")
-o:value("86400", "24 小时")
+o = s:option(ListValue, "window", translate("Failure window (seconds)"))
+o.description = translate("Time window for counting failures. Counter resets if no failures occur within this period.")
+o:value("300", translate("5 minutes"))
+o:value("600", translate("10 minutes"))
+o:value("1800", translate("30 minutes"))
+o:value("3600", translate("1 hour"))
+o:value("86400", translate("24 hours"))
 o.default = "600"
 
-o = s:option(ListValue, "bantime", "封禁时长")
-o:value("3600", "1 小时")
-o:value("21600", "6 小时")
-o:value("43200", "12 小时")
-o:value("86400", "24 小时")
-o:value("604800", "1 周")
-o:value("2592000", "30 天")
+o = s:option(ListValue, "bantime", translate("Ban duration"))
+o:value("3600", translate("1 hour"))
+o:value("21600", translate("6 hours"))
+o:value("43200", translate("12 hours"))
+o:value("86400", translate("24 hours"))
+o:value("604800", translate("1 week"))
+o:value("2592000", translate("30 days"))
 o.default = "43200"
 
-o = s:option(DynamicList, "whitelist", "白名单（额外）")
-o.description = "除了 LAN 私有段（192.168.x、10.x、127.x、172.16-31.x）默认豁免外，再加这些 IP/CIDR。" ..
-                "支持单 IP（如 1.2.3.4）或 /8 /16 /24 /32 子网。"
-o.placeholder = "如 8.8.8.8 或 203.0.113.0/24"
+o = s:option(DynamicList, "whitelist", translate("Whitelist (extra)"))
+o.description = translate("In addition to LAN private ranges (192.168.x, 10.x, 127.x, 172.16-31.x) which are always exempt, add these IPs/CIDRs.") ..
+                " " .. translate("Supports single IP (e.g. 1.2.3.4) or /8 /16 /24 /32 subnets.")
+o.placeholder = "e.g. 8.8.8.8 or 203.0.113.0/24"
 
 return m

--- a/luasrc/model/cbi/minigate/proxy.lua
+++ b/luasrc/model/cbi/minigate/proxy.lua
@@ -2,7 +2,7 @@ local m, s, o
 local sys = require "luci.sys"
 local uc = require "luci.model.uci".cursor()
 
-m = Map("minigate", "MiniGate - 反向代理", "保存后自动生效。")
+m = Map("minigate", translate("MiniGate - Reverse Proxy"), translate("Changes take effect automatically after save."))
 
 m.on_after_commit = function(self)
     sys.call("sleep 1 && /bin/sh /usr/lib/minigate/proxy.sh reload >/dev/null 2>&1 &")
@@ -31,49 +31,49 @@ end)
 -- ================================
 if #wildcard_domains > 0 then
 
-s = m:section(TypedSection, "proxy_wildcard", "通配符域名",
-    "配置监听端口和HTTPS，具体转发由「子域名」控制。")
-s.anonymous = false
+s = m:section(TypedSection, "proxy_wildcard", translate("Wildcard domains"),
+    translate("Configure listening port and HTTPS. Forwarding is controlled by subdomain rules."))
+s.anonymous = true
 s.addremove = true
 s.template = "cbi/tblsection"
-s.sectionhead = "名称"
 
-o = s:option(ListValue, "enabled", "启用")
-o:value("1", "✓ 启用")
-o:value("0", "✗ 禁用")
+o = s:option(Value, "name", translate("Name"))
+o.rmempty = true
+o.placeholder = translate("e.g. my-site")
+
+o = s:option(ListValue, "enabled", translate("Enable"))
+o:value("1", translate("Enabled"))
+o:value("0", translate("Disabled"))
 o.default = "1"
 o.rmempty = false
 
-o = s:option(ListValue, "domain", "域名")
-o:value("", "-- 请选择 --")
+o = s:option(ListValue, "domain", translate("Domain"))
+o:value("", "-- " .. translate("Select") .. " --")
 for _, d in ipairs(wildcard_domains) do
     local label = d
     if ddns_ok[d] then label = d .. " ✓" end
     o:value(d, label)
 end
-o.rmempty = false
+o.rmempty = true
 
-o = s:option(Value, "listen_port", "监听端口")
+o = s:option(Value, "listen_port", translate("Listen port"))
 o.datatype = "port"
 o.default = "2000"
-o.rmempty = false
+o.rmempty = true
 
 o = s:option(ListValue, "ssl", "HTTPS")
-o:value("1", "✓ 开启")
-o:value("0", "✗ 关闭")
+o:value("1", translate("Enabled"))
+o:value("0", translate("Disabled"))
 o.default = "1"
 o.rmempty = false
 
--- ================================
--- 子域名规则
--- ================================
-s = m:section(TypedSection, "subproxy", "子域名规则")
+s = m:section(TypedSection, "subproxy", translate("Subdomain rules"))
 s.anonymous = true
 s.addremove = true
 s.sortable = true
 s.template = "cbi/tblsection"
 
-o = s:option(ListValue, "parent_domain", "主域名")
+o = s:option(ListValue, "parent_domain", translate("Parent domain"))
 o:value("", "--")
 for _, d in ipairs(wildcard_domains) do
     local base = d:gsub("^%*%.", "")
@@ -81,20 +81,20 @@ for _, d in ipairs(wildcard_domains) do
 end
 o.rmempty = false
 
-o = s:option(Value, "prefix", "前缀")
+o = s:option(Value, "prefix", translate("Prefix"))
 o.rmempty = false
 o.placeholder = "app"
 
-o = s:option(Value, "target_addr", "目标地址")
+o = s:option(Value, "target_addr", translate("Target address"))
 o.rmempty = false
 o.placeholder = "192.168.1.100"
 
-o = s:option(Value, "target_port", "端口")
+o = s:option(Value, "target_port", translate("Port"))
 o.datatype = "port"
 o.default = "80"
 o.rmempty = false
 
-o = s:option(DummyValue, "_final", "实际域名")
+o = s:option(DummyValue, "_final", translate("Resolved domain"))
 o.rawhtml = true
 o.cfgvalue = function(self, section)
     local base = m.uci:get("minigate", section, "parent_domain") or ""
@@ -112,52 +112,55 @@ end -- wildcard_domains
 -- ================================
 if #normal_domains > 0 or #wildcard_domains == 0 then
 
-s = m:section(TypedSection, "proxy", "代理规则",
-    "非通配符域名的反向代理。")
-s.anonymous = false
+s = m:section(TypedSection, "proxy", translate("Proxy rules"),
+    translate("Reverse proxy for non-wildcard domains."))
+s.anonymous = true
 s.addremove = true
 s.template = "cbi/tblsection"
 s.sortable = true
-s.sectionhead = "名称"
 
-o = s:option(ListValue, "enabled", "启用")
-o:value("1", "✓ 启用")
-o:value("0", "✗ 禁用")
+o = s:option(Value, "name", translate("Name"))
+o.rmempty = true
+o.placeholder = translate("e.g. my-site")
+
+o = s:option(ListValue, "enabled", translate("Enable"))
+o:value("1", translate("Enabled"))
+o:value("0", translate("Disabled"))
 o.default = "1"
 o.rmempty = false
 
-o = s:option(ListValue, "domain", "域名")
-o:value("", "-- 请选择 --")
+o = s:option(ListValue, "domain", translate("Domain"))
+o:value("", "-- " .. translate("Select") .. " --")
 for _, d in ipairs(normal_domains) do
     local label = d
     if ddns_ok[d] then label = d .. " ✓" end
     o:value(d, label)
 end
-o.rmempty = false
+o.rmempty = true
 
-o = s:option(Value, "listen_port", "端口")
+o = s:option(Value, "listen_port", translate("Port"))
 o.datatype = "port"
 o.default = "443"
-o.rmempty = false
+o.rmempty = true
 
-o = s:option(Value, "target_addr", "目标地址")
-o.rmempty = false
+o = s:option(Value, "target_addr", translate("Target address"))
+o.rmempty = true
 o.placeholder = "192.168.1.100"
 
-o = s:option(Value, "target_port", "目标端口")
+o = s:option(Value, "target_port", translate("Target port"))
 o.datatype = "port"
 o.default = "80"
-o.rmempty = false
+o.rmempty = true
 
 o = s:option(ListValue, "ssl", "HTTPS")
-o:value("1", "✓ 开启")
-o:value("0", "✗ 关闭")
+o:value("1", translate("Enabled"))
+o:value("0", translate("Disabled"))
 o.default = "1"
 o.rmempty = false
 
 o = s:option(ListValue, "websocket", "WS")
-o:value("0", "✗ 关闭")
-o:value("1", "✓ 开启")
+o:value("0", translate("Disabled"))
+o:value("1", translate("Enabled"))
 o.default = "0"
 o.rmempty = false
 

--- a/luasrc/view/minigate/log.htm
+++ b/luasrc/view/minigate/log.htm
@@ -1,18 +1,20 @@
 <%+header%>
-<h2>MiniGate - 日志</h2>
+<h2>MiniGate - <%:Log%></h2>
 <div style="margin-bottom:15px">
 <select id="ls" style="padding:5px 10px;border-radius:4px;border:1px solid #ccc">
-<option value="all">全部</option><option value="ddns">DDNS</option><option value="acme">ACME</option><option value="proxy">代理</option>
+<option value="all"><%:All%></option><option value="ddns">DDNS</option><option value="acme">ACME</option><option value="proxy"><%:Proxy%></option>
 </select>
-<button class="cbi-button cbi-button-action" onclick="rl()" style="margin-left:10px">刷新</button>
-<label style="margin-left:15px"><input type="checkbox" id="ar" checked> 自动刷新(5秒)</label>
+<button class="cbi-button cbi-button-action" onclick="rl()" style="margin-left:10px"><%:Refresh%></button>
+<label style="margin-left:15px"><input type="checkbox" id="ar" checked> <%:Auto-refresh%> (<%:5s%>)</label>
 </div>
-<pre id="lc" style="background:#1e1e2e;color:#cdd6f4;font-family:monospace;font-size:12px;line-height:1.5;padding:15px;border-radius:8px;max-height:600px;overflow-y:auto;white-space:pre-wrap;word-break:break-all;margin:0">加载中...</pre>
+<pre id="lc" style="background:#1e1e2e;color:#cdd6f4;font-family:monospace;font-size:12px;line-height:1.5;padding:15px;border-radius:8px;max-height:600px;overflow-y:auto;white-space:pre-wrap;word-break:break-all;margin:0">...<%:Loading...%></pre>
 <script type="text/javascript">
 var lt;
 var lu='<%=luci.dispatcher.build_url("admin/services/minigate/get_log")%>';
+var _s_empty='(<%:empty%>)';
+var _s_unreadable='(<%:unable to read%>)';
 function rl(){var s=document.getElementById('ls').value;var c=document.getElementById('lc');
-XHR.get(lu,{source:s},function(x,d){if(d&&d.log){c.textContent=d.log||'（暂无）';c.scrollTop=c.scrollHeight}else c.textContent='（无法读取）'})}
+XHR.get(lu,{source:s},function(x,d){if(d&&d.log){c.textContent=d.log||_s_empty;c.scrollTop=c.scrollHeight}else c.textContent=_s_unreadable})}
 function sa(){if(lt)clearInterval(lt);if(document.getElementById('ar').checked)lt=setInterval(rl,5000)}
 document.getElementById('ar').addEventListener('change',sa);
 document.getElementById('ls').addEventListener('change',rl);

--- a/po/zh_Hans/minigate.po
+++ b/po/zh_Hans/minigate.po
@@ -1,11 +1,543 @@
 msgid ""
-msgstr "Content-Type: text/plain; charset=UTF-8\n"
+msgstr ""
+"Content-Type: text/plain; charset=UTF-8\n"
 "Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+# ── controller / shared ───────────────────────────────────────────────────────
+
+msgid "Overview"
+msgstr "总览"
+
+msgid "Dynamic DNS"
+msgstr "动态 DNS"
+
+msgid "SSL Certificate"
+msgstr "SSL 证书"
+
+msgid "Reverse Proxy"
+msgstr "反向代理"
+
+msgid "Login Guard"
+msgstr "登录防护"
+
+msgid "Log"
+msgstr "日志"
+
+msgid "Installation successful"
+msgstr "安装成功"
+
+msgid "Installation failed"
+msgstr "安装失败"
+
+msgid "Certificate issued successfully"
+msgstr "签发成功！"
+
+msgid "Certificate issuance failed, check log"
+msgstr "签发失败，请查看日志"
+
+msgid "Invalid IP"
+msgstr "无效 IP"
+
+msgid "Unknown"
+msgstr "未知"
+
+# ── general.lua ───────────────────────────────────────────────────────────────
+
+msgid "MiniGate Gateway"
+msgstr "MiniGate 轻网关"
+
+msgid "Lightweight gateway management: DDNS (IPv4/IPv6 dual-stack), SSL certificate issuance, reverse proxy."
+msgstr "轻量级网关管理：动态域名解析（IPv4/IPv6 双栈）、SSL 证书签发、反向代理。"
+
+msgid "Service Status"
+msgstr "服务状态"
+
+msgid "Global Settings"
+msgstr "全局设置"
+
+msgid "Enable MiniGate"
+msgstr "启用 MiniGate"
+
+msgid "Master switch. Disabling stops DDNS cron, ACME renewal and reverse proxy. Takes effect immediately after save."
+msgstr "总开关。关闭后停止 DDNS 定时任务、ACME 续期和反向代理。保存后立即生效。"
+
+msgid "Reverse proxy listen on IPv6"
+msgstr "反向代理监听 IPv6"
+
+msgid "When enabled, Nginx reverse proxy also listens on IPv6 (listen [::]:port)."
+msgstr "开启后，Nginx 反向代理将同时监听 IPv4 和 IPv6 地址（listen [::]:port）。"
+
+# ── ddns.lua ──────────────────────────────────────────────────────────────────
+
+msgid "MiniGate - Dynamic DNS"
+msgstr "MiniGate - 动态 DNS"
+
+msgid "Supports multiple domains and IPv4/IPv6 dual-stack. Syncs immediately after save. Requires global switch to be enabled."
+msgstr "支持多域名、IPv4/IPv6 双栈。保存后立即同步。需先启用全局开关。"
+
+msgid "DDNS Records"
+msgstr "DDNS 记录"
+
+msgid "Enable"
+msgstr "启用"
+
+msgid "Domain"
+msgstr "域名"
+
+msgid "API Token"
+msgstr "API 令牌"
+
+msgid "IP Version"
+msgstr "协议版本"
+
+msgid "IPv4 only (A record)"
+msgstr "仅 IPv4（A 记录）"
+
+msgid "IPv6 only (AAAA record)"
+msgstr "仅 IPv6（AAAA 记录）"
+
+msgid "Dual-stack (A + AAAA)"
+msgstr "双栈（A + AAAA）"
+
+msgid "Select which DNS record type to update. Dual-stack updates both A and AAAA records."
+msgstr "选择更新哪种 DNS 记录。双栈模式同时更新 A 和 AAAA 记录。"
+
+msgid "IP Source"
+msgstr "IP 来源"
+
+msgid "From network interface"
+msgstr "从网卡获取"
+
+msgid "From external URL"
+msgstr "从外部 URL 获取"
+
+msgid "IPv4 network interface"
+msgstr "IPv4 网络接口"
+
+msgid "IPv4 detection URL"
+msgstr "IPv4 获取地址"
+
+msgid "In NAT/proxy environments, bypasses proxy to get the real public IP."
+msgstr "旁路由/代理环境自动绕过代理直连获取真实公网 IP。"
+
+msgid "IPv6 network interface"
+msgstr "IPv6 网络接口"
+
+msgid "Interface used to obtain the IPv6 address (usually wan6)."
+msgstr "用于获取 IPv6 地址的接口（通常为 wan6）。"
+
+msgid "IPv6 detection URL"
+msgstr "IPv6 获取地址"
+
+msgid "Fetches address via IPv6-only connection."
+msgstr "仅通过 IPv6 连接获取地址。"
+
+msgid "Interval (seconds)"
+msgstr "间隔（秒）"
+
+msgid "Status"
+msgstr "运行状态"
+
+# ── acme.lua ──────────────────────────────────────────────────────────────────
+
+msgid "MiniGate - SSL Certificate"
+msgstr "MiniGate - SSL 证书"
+
+msgid "Automatic ACME (Let's Encrypt) certificate issuance. Domain and token are auto-linked from Dynamic DNS."
+msgstr "ACME（Let's Encrypt）自动签发。域名和令牌自动关联「动态 DNS」。"
+
+msgid "ACME Settings"
+msgstr "ACME 设置"
+
+msgid "Enable ACME"
+msgstr "启用 ACME"
+
+msgid "Account email"
+msgstr "账户邮箱"
+
+msgid "Optional."
+msgstr "可选。"
+
+msgid "Key type"
+msgstr "密钥类型"
+
+msgid "recommended"
+msgstr "推荐"
+
+msgid "Staging mode"
+msgstr "测试模式"
+
+msgid "Disable for production use."
+msgstr "正式使用请关闭。"
+
+msgid "Issued certificates"
+msgstr "已签发证书"
+
+msgid "acme.sh status"
+msgstr "acme.sh 状态"
+
+msgid "Actions"
+msgstr "操作"
+
+# ── proxy.lua ─────────────────────────────────────────────────────────────────
+
+msgid "MiniGate - Reverse Proxy"
+msgstr "MiniGate - 反向代理"
+
+msgid "Changes take effect automatically after save."
+msgstr "保存后自动生效。"
+
+msgid "Wildcard domains"
+msgstr "通配符域名"
+
+msgid "Configure listening port and HTTPS. Forwarding is controlled by subdomain rules."
+msgstr "配置监听端口和 HTTPS，具体转发由「子域名」控制。"
+
+msgid "Name"
+msgstr "名称"
+
+msgid "Enabled"
+msgstr "✓ 启用"
+
+msgid "Disabled"
+msgstr "✗ 禁用"
+
+msgid "Select"
+msgstr "请选择"
+
+msgid "Listen port"
+msgstr "监听端口"
+
+msgid "Subdomain rules"
+msgstr "子域名规则"
+
+msgid "Parent domain"
+msgstr "主域名"
+
+msgid "Prefix"
+msgstr "前缀"
+
+msgid "Target address"
+msgstr "目标地址"
+
+msgid "Port"
+msgstr "端口"
+
+msgid "Resolved domain"
+msgstr "实际域名"
+
+msgid "Proxy rules"
+msgstr "代理规则"
+
+msgid "Reverse proxy for non-wildcard domains."
+msgstr "非通配符域名的反向代理。"
+
+msgid "Target port"
+msgstr "目标端口"
+
+# ── login_guard.lua ───────────────────────────────────────────────────────────
+
+msgid "Monitors SSH (dropbear) and LuCI login failures and auto-bans source IPs on threshold."
+msgstr "监控 SSH（dropbear）和 LuCI 网页登录失败，达到阈值自动封禁源 IP。"
+
+msgid "Intended for SSH ports exposed to the internet. LAN private IPs are always exempt."
+msgstr "适用于 SSH 端口被映射到公网、防爆破。LAN 私有 IP 自动豁免。"
+
+msgid "Live Status"
+msgstr "实时状态"
+
+msgid "Settings"
+msgstr "设置"
+
+msgid "Enable Login Guard"
+msgstr "启用登录防护"
+
+msgid "When enabled, SSH/LuCI login failures are monitored. LAN IPs are never banned."
+msgstr "开启后将自动监控 SSH/LuCI 失败登录。LAN IP 永远不会被封禁。"
+
+msgid "Failure threshold"
+msgstr "失败次数阈值"
+
+msgid "Number of failures within the window that triggers a ban."
+msgstr "在「失败窗口」时间内累积达到此次数则封禁。"
+
+msgid "Failure window (seconds)"
+msgstr "失败窗口（秒）"
+
+msgid "Time window for counting failures. Counter resets if no failures occur within this period."
+msgstr "在多长时间内累计失败次数。超过此时间未再失败则计数清零。"
+
+msgid "5 minutes"
+msgstr "5 分钟"
+
+msgid "10 minutes"
+msgstr "10 分钟"
+
+msgid "30 minutes"
+msgstr "30 分钟"
+
+msgid "1 hour"
+msgstr "1 小时"
+
+msgid "24 hours"
+msgstr "24 小时"
+
+msgid "Ban duration"
+msgstr "封禁时长"
+
+msgid "6 hours"
+msgstr "6 小时"
+
+msgid "12 hours"
+msgstr "12 小时"
+
+msgid "1 week"
+msgstr "1 周"
+
+msgid "30 days"
+msgstr "30 天"
+
+msgid "Whitelist (extra)"
+msgstr "白名单（额外）"
+
+msgid "In addition to LAN private ranges (192.168.x, 10.x, 127.x, 172.16-31.x) which are always exempt, add these IPs/CIDRs."
+msgstr "除了 LAN 私有段（192.168.x、10.x、127.x、172.16-31.x）默认豁免外，再加这些 IP/CIDR。"
+
+msgid "Supports single IP (e.g. 1.2.3.4) or /8 /16 /24 /32 subnets."
+msgstr "支持单 IP（如 1.2.3.4）或 /8 /16 /24 /32 子网。"
+
+# ── menu / acl ────────────────────────────────────────────────────────────────
 
 msgid "MiniGate"
 msgstr "MiniGate 轻网关"
 
 msgid "Grant UCI access for luci-app-minigate"
 msgstr "授予 luci-app-minigate UCI 访问权限"
+
+# ── general.lua status card / table ───────────────────────────────────────────
+
+msgid "SSL/TLS Certificate"
+msgstr "SSL/TLS 证书"
+
+msgid "Access Log"
+msgstr "访问日志"
+
+msgid "Show"
+msgstr "显示"
+
+msgid "IP Address"
+msgstr "IP 地址"
+
+msgid "Location"
+msgstr "归属地"
+
+msgid "Last Visit"
+msgstr "最后访问"
+
+msgid "Count"
+msgstr "次数"
+
+msgid "Loading..."
+msgstr "加载中..."
+
+msgid "No access records yet."
+msgstr "暂无访问记录。"
+
+msgid "Online"
+msgstr "在线"
+
+msgid "Offline"
+msgstr "离线"
+
+msgid "Querying..."
+msgstr "查询中..."
+
+msgid "Not configured"
+msgstr "未配置"
+
+msgid "Expires: "
+msgstr "到期："
+
+msgid "Updated: "
+msgstr "已更新："
+
+msgid "Next: "
+msgstr "下次："
+
+msgid "Nginx running"
+msgstr "Nginx 运行中"
+
+msgid "Running"
+msgstr "运行中"
+
+msgid "Stopped"
+msgstr "已停止"
+
+msgid "Valid"
+msgstr "有效"
+
+# ── ddns.lua status ────────────────────────────────────────────────────────────
+
+msgid "Partial"
+msgstr "部分同步"
+
+msgid "Error"
+msgstr "错误"
+
+msgid "Not synced"
+msgstr "未同步"
+
+msgid "Sync now"
+msgstr "立即同步"
+
+msgid "Syncing..."
+msgstr "同步中..."
+
+msgid "Failed"
+msgstr "失败"
+
+# ── acme.lua ───────────────────────────────────────────────────────────────────
+
+msgid "Expires"
+msgstr "到期时间"
+
+msgid "Path"
+msgstr "路径"
+
+msgid "No certificates found."
+msgstr "未找到证书。"
+
+msgid "Installed"
+msgstr "已安装"
+
+msgid "DNS plugin missing"
+msgstr "DNS 插件缺失"
+
+msgid "Not installed"
+msgstr "未安装"
+
+msgid "Download and install acme.sh"
+msgstr "下载并安装 acme.sh"
+
+msgid "Issue domain:"
+msgstr "签发域名："
+
+msgid "Configure Dynamic DNS first"
+msgstr "请先配置动态 DNS"
+
+msgid "Issue / Renew"
+msgstr "签发 / 续签"
+
+msgid "Processing..."
+msgstr "处理中..."
+
+msgid "Downloading and installing (about 30 seconds)..."
+msgstr "正在下载并安装（约 30 秒）..."
+
+msgid "Please select a domain"
+msgstr "请选择域名"
+
+msgid "Timeout"
+msgstr "超时"
+
+# ── login_guard.lua ────────────────────────────────────────────────────────────
+
+msgid "Currently Banned"
+msgstr "当前封禁"
+
+msgid "Counting Failures"
+msgstr "计数失败"
+
+msgid "Banned IP List"
+msgstr "封禁 IP 列表"
+
+msgid "Counting Failures (below threshold)"
+msgstr "失败计数（未达阈值）"
+
+msgid "Enter IP to ban"
+msgstr "输入要封禁的 IP"
+
+msgid "Ban"
+msgstr "封禁"
+
+msgid "Flush All"
+msgstr "清除全部"
+
+msgid "Failures"
+msgstr "失败次数"
+
+msgid "Last Seen"
+msgstr "最后出现"
+
+msgid "Since First Failure"
+msgstr "首次失败至今"
+
+msgid "Remaining"
+msgstr "剩余时间"
+
+msgid "Action"
+msgstr "操作"
+
+msgid "None"
+msgstr "无"
+
+msgid "No bans."
+msgstr "暂无封禁。"
+
+msgid "Not running"
+msgstr "未运行"
+
+msgid "Unban"
+msgstr "解封"
+
+msgid "Confirm unban"
+msgstr "确认解封"
+
+msgid "Please enter an IP"
+msgstr "请输入 IP 地址"
+
+msgid "Invalid IP format"
+msgstr "IP 格式无效"
+
+msgid "Confirm flush all bans? This cannot be undone."
+msgstr "确认清除所有封禁？此操作不可撤销。"
+
+msgid "Refresh failed, please retry."
+msgstr "刷新失败，请重试。"
+
+msgid "Render error: "
+msgstr "渲染错误："
+
+# ── log.htm ────────────────────────────────────────────────────────────────────
+
+msgid "All"
+msgstr "全部"
+
+msgid "Proxy"
+msgstr "代理"
+
+msgid "Refresh"
+msgstr "刷新"
+
+msgid "Auto-refresh"
+msgstr "自动刷新"
+
+msgid "5s"
+msgstr "5秒"
+
+msgid "empty"
+msgstr "空"
+
+msgid "unable to read"
+msgstr "无法读取"
+
+# ── acme.lua extra ─────────────────────────────────────────────────────────────
+
+msgid "Issuing"
+msgstr "正在签发"
+
+msgid "e.g. my-site"
+msgstr "例：my-site"
+

--- a/po/zh_Hans/minigate.po
+++ b/po/zh_Hans/minigate.po
@@ -1,0 +1,11 @@
+msgid ""
+msgstr "Content-Type: text/plain; charset=UTF-8\n"
+"Language: zh_CN\n"
+"MIME-Version: 1.0\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+msgid "MiniGate"
+msgstr "MiniGate 轻网关"
+
+msgid "Grant UCI access for luci-app-minigate"
+msgstr "授予 luci-app-minigate UCI 访问权限"

--- a/root/usr/share/luci/menu.d/luci-app-minigate.json
+++ b/root/usr/share/luci/menu.d/luci-app-minigate.json
@@ -4,9 +4,6 @@
 		"order": 60,
 		"action": {
 			"type": "firstchild"
-		},
-		"depends": {
-			"acl": [ "luci-app-minigate" ]
 		}
 	}
 }

--- a/root/usr/share/luci/menu.d/luci-app-minigate.json
+++ b/root/usr/share/luci/menu.d/luci-app-minigate.json
@@ -1,0 +1,12 @@
+{
+	"admin/services/minigate": {
+		"title": "MiniGate",
+		"order": 60,
+		"action": {
+			"type": "firstchild"
+		},
+		"depends": {
+			"acl": [ "luci-app-minigate" ]
+		}
+	}
+}

--- a/root/usr/share/rpcd/acl.d/luci-app-minigate.json
+++ b/root/usr/share/rpcd/acl.d/luci-app-minigate.json
@@ -1,0 +1,24 @@
+{
+	"luci-app-minigate": {
+		"description": "Grant UCI access for luci-app-minigate",
+		"read": {
+			"ubus": {
+				"session": [ "access", "login" ]
+			},
+			"uci": [ "minigate" ],
+			"file": {
+				"/var/log/minigate-*.log": [ "read" ],
+				"/var/run/minigate-nginx.pid": [ "read" ],
+				"/var/run/minigate/login-guard/counters/*": [ "read" ],
+				"/etc/minigate/certs/*": [ "read" ],
+				"/etc/minigate/acme/data/acme.sh": [ "read" ],
+				"/etc/minigate/acme/data/dnsapi/dns_cf.sh": [ "read" ],
+				"/etc/crontabs/root": [ "read" ],
+				"/tmp/minigate-geo-cache/*": [ "read", "write" ]
+			}
+		},
+		"write": {
+			"uci": [ "minigate" ]
+		}
+	}
+}


### PR DESCRIPTION
## Summary

This PR modernizes the package for compatibility with current LuCI versions and completes the zh_Hans (Simplified Chinese) internationalization.

### Fixes
- Fix missing menu entry and 403 error by adding `luci-compat` dependency and adjusting `menu.d`/`acl.d` JSON files
- Fix Lua syntax errors in `ddns.lua` (stray backslash) and `acme.lua` (single-quoted multiline string)

### i18n Improvements
- Complete zh_Hans translations for all UI strings, including embedded HTML/JS blocks in `general.lua`, `ddns.lua`, `acme.lua`, `login_guard.lua`
- Translate status labels: Disabled / Running / Partial / Error / Stopped etc.
- `log.htm`: translate title, filter options, buttons, auto-refresh label and JS dynamic strings via LuCI `<%:...%>` tags
- Add 80+ translation entries to `po/zh_Hans/minigate.po`; remove duplicate `msgid` entries

### UI / UX
- `proxy.lua`: replace `anonymous=false` section name column with an explicit `Value 'name'` field so all columns use the same widget rendering pipeline — no more mismatched backgrounds or cramped headers
- Set `rmempty=true` on optional proxy fields to prevent spurious `missing` validation errors on legacy UCI data